### PR TITLE
feat(work): /work supports Linear Document deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then run `/work YOUR-123` on any Linear issue.
 ## What you get
 
 - **`loom` CLI** — `@juliushamm/loom` on npm. Five pipeline subcommands (`preflight`, `poll-dispatch`, `poll-ci`, `merge-gate`, `cleanup`) plus three setup subcommands (`init`, `labels`, `doctor`).
-- **`/work` skill** — Claude Code skill that orchestrates the full pipeline. Reads config from `.loom.json`.
+- **`/work` skill** — Claude Code skill that orchestrates the full pipeline. Reads config from `.loom.json`. Supports two deliverable shapes: **code** (subagent opens a PR; CI is polled) and **Linear Document** (subagent creates/updates a doc on the named project via the Linear MCP; no PR, no file writes).
 - **Dev-team template** — a seven-persona skeleton (Lead, Architect, Frontend, Backend, Security, QA, Scribe) that the `build-team` skill fills in via an interactive interview.
 
 ## Prerequisites

--- a/docs/dispatch-gate.md
+++ b/docs/dispatch-gate.md
@@ -34,7 +34,7 @@ If both `dispatch-ok` and `dispatch-reject` are present on the issue simultaneou
 - **Scope** — exact files/directories that may be touched. Explicit list beats "the relevant code."
 - **Verification** — commands that prove it works. `npm test`, `npm run typecheck`, `npm run lint`, plus any feature-specific manual step.
 - **Out of scope** — an explicit list of things the subagent must NOT do. Often the most valuable section — catches scope creep before it starts.
-- **Output format** — what the subagent returns to the orchestrator (diff, log, PR URL).
+- **Output format** — what the subagent returns to the orchestrator. For code deliverables: diff + PR URL. For Linear-Document deliverables: the Document URL on the named project (no filesystem writes).
 
 **Red flags:**
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -78,9 +78,9 @@ What happens:
 2. **Meeting.** Your team personas convene in-character. Lead opens, relevant agents speak, Lead closes with a decision.
 3. **Scribe posts the dispatch prompt** to Linear as a comment, tagged `automation:dispatch-pending-review`.
 4. **You review the prompt** in Linear. Apply `automation:dispatch-ok` to proceed, `automation:dispatch-reject` to send it back for revision.
-5. **Execution.** Loom dispatches a subagent with the approved prompt. The subagent opens a PR before returning.
-6. **CI poll.** Loom watches for CI to go green (or red).
-7. **Hand-off.** On green, loom posts `automation:awaiting-merge` and stops. You review the diff and merge the PR manually.
+5. **Execution.** Loom dispatches a subagent with the approved prompt. **Code deliverables**: the subagent opens a PR before returning. **Linear-Document deliverables** (Lead declared `Deliverable: LINEAR DOCUMENT` in step 2): the subagent creates a Linear Document on the named project via the Linear MCP and returns the Document URL — no PR, no file on disk.
+6. **CI poll** (code path) **or document hand-off** (document path). For code, loom watches CI to go green (or red). For documents, loom posts the URL and exits — there's no CI to poll.
+7. **Hand-off.** Code path: on green, loom posts `automation:awaiting-merge` and stops; you review the diff and merge the PR manually. Document path: loom posts `automation:awaiting-review` with the Document URL; you review the doc, sign off in-document, and move the issue state when done.
 8. **Cleanup.** Loom releases the in-flight lock and removes the heartbeat label.
 
 ## Troubleshooting

--- a/skills/dev-team-template/SKILL.md.template
+++ b/skills/dev-team-template/SKILL.md.template
@@ -27,8 +27,8 @@ Seven personas. Use this skill whenever the user wants a multi-perspective desig
 
 1. **Foreman/Lead opens** — frames the question, names the scope.
 2. **Focused discussion** — only agents whose expertise applies. No round-robin. Push back, build on each other, cite concrete things.
-3. **Lead closes** — calls the decision, names the next step, names the executor.
-4. **Scribe outputs the dispatch prompt** — a self-contained subagent brief with goal, context, scope, verification, out-of-scope, output format.
+3. **Lead closes** — calls the decision, names the next step, names the executor, **and declares the deliverable type** as a single line: `Deliverable: CODE` (a PR) or `Deliverable: LINEAR DOCUMENT` (a spec/plan on a named project).
+4. **Scribe outputs the dispatch prompt** — chooses one of two templates based on Lead's declaration: a CODE-shaped brief (goal/context/scope/verification/out-of-scope, opens a PR) or a LINEAR DOCUMENT brief (creates/updates a doc via Linear MCP, returns a URL, no filesystem writes).
 
 ## When to use this skill
 

--- a/skills/dev-team-template/agents/scribe.md.template
+++ b/skills/dev-team-template/agents/scribe.md.template
@@ -19,6 +19,12 @@ Auditor + Librarian. Quiet, obsessive, organized. Documents everything. Never pa
 
 ## Dispatch Format
 
+Scribe emits one of two templates, chosen by the Lead's closing `Deliverable:` declaration. Wrong template = wrong outcome — the classification is load-bearing, not decorative.
+
+### Template A — CODE
+
+Used when Lead names `Deliverable: CODE`. Produces a PR in the consumer repo.
+
 ```
 SUBAGENT DISPATCH — <date>
 
@@ -39,5 +45,47 @@ VERIFICATION:
 OUT OF SCOPE:
 - <explicit exclusions>
 
-OUTPUT: <diff / log / spec / etc.>
+OUTPUT: <diff / log / etc.> Opens a PR titled "...".
+
+REPO: <consumer repo path>
+BRANCH: <Linear gitBranchName>
+PROFILE: <profile from .loom.json>
 ```
+
+### Template B — LINEAR DOCUMENT
+
+Used when Lead names `Deliverable: LINEAR DOCUMENT`. Produces a Linear Document on the named project — not a PR, not a file on disk. The subagent MUST NOT write markdown into any repo.
+
+```
+SUBAGENT DISPATCH — <date>
+
+TASK: <one-line goal — "Write a spec for X" or "Update the X plan">
+
+CONTEXT:
+- <why this task, grounded in meeting discussion>
+- <prior findings or learnings that matter>
+
+SCOPE:
+- <what sections the document must cover>
+- <constraints on shape, vocabulary, cross-references>
+
+VERIFICATION:
+- <self-check the subagent runs before calling done>
+- <readability / sign-off bar from the meeting>
+
+OUT OF SCOPE:
+- <explicit exclusions>
+- filesystem writes to any repo (specs/plans live in Linear, not on disk)
+
+OUTPUT: Linear Document via `mcp__linear-server__create_document`
+  PROJECT: <project name>
+  TITLE: <document title>
+  CONTENT: <full markdown body>
+
+Subagent returns the Document URL. No branch, no PR, no file on disk.
+
+REVIEWERS: <names from the meeting — sign-off checkpoints>
+PROFILE: <profile from .loom.json>
+```
+
+Both templates are intentionally terse. Brief, don't bark.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -19,6 +19,8 @@ Parse the JSON. Route on `state`:
 - `merge-ready` → skip to §6 (human merges)
 - `abort-*` → tell user + exit
 
+Note: the probe reasons over git/GitHub state only. For Linear-Document deliverables it always returns `fresh` — duplicate-document avoidance is the reviewer's responsibility until the probe learns to see Linear Documents.
+
 ## 2. Triage (if no team:* labels)
 
 Use Linear MCP `get_issue` to read the issue. Apply your team's layered triage rule (Owner field → keywords → LLM judgment) to assign the correct `team:*` labels. Apply labels via `save_issue`. Post a `🟡 automation:triage` comment summarizing your reasoning.
@@ -27,7 +29,14 @@ The meeting participant labels are: `team:lead`, plus whatever personas `.claude
 
 ## 3. Meeting
 
-Read labeled persona files from `.claude/skills/{{teamSkillName}}/agents/*.md`. Read any agents marked as always-present in that skill's SKILL.md (typically Lead + Scribe). Run the focused team meeting in-character. Close with an executor choice. The Scribe persona emits the dispatch prompt at meeting end.
+Read labeled persona files from `.claude/skills/{{teamSkillName}}/agents/*.md`. Read any agents marked as always-present in that skill's SKILL.md (typically Lead + Scribe). Run the focused team meeting in-character.
+
+**Lead's closing MUST name the deliverable type explicitly**, as a single line:
+
+- `Deliverable: CODE` — a PR in the consumer repo (source files, CI config, tests).
+- `Deliverable: LINEAR DOCUMENT` — a spec, plan, or design doc. Lead names the Linear project the document attaches to and whether this creates a new document or updates an existing one.
+
+Scribe reads Lead's declaration and emits the matching dispatch template (see Scribe's persona for the two templates). Wrong template = wrong outcome — the classification is load-bearing, not decorative.
 
 ## 4. Dispatch-review gate (paranoid step 3)
 
@@ -48,13 +57,14 @@ Reject evaluation happens before ok — if both labels present simultaneously, r
 
 ## 5. Execution (Agent tool subagent)
 
-Invoke the `Agent` tool with `subagent_type: "general-purpose"` and `prompt: <Scribe's dispatch prompt + repo path + profile + Tier 1 hook reminder>`. The subagent should open a PR before returning.
+Invoke the `Agent` tool with `subagent_type: "general-purpose"` and `prompt: <Scribe's dispatch prompt + profile + Tier 1 hook reminder>`. Collect the result.
 
-Collect the PR number from the subagent's result.
+- **CODE path:** include the consumer repo path and target branch in the dispatch. Subagent opens a PR before returning; capture the PR number.
+- **DOCUMENT path:** do **not** include a repo path. Subagent creates (or updates) a Linear Document via the Linear MCP `mcp__linear-server__create_document` / `update_document` tool and returns the Document URL. No branch, no PR, no file on disk. Subagent MUST NOT write markdown into the consumer repo's filesystem — silently sneaking design docs into source trees can violate the consumer's own policies (gitignore, OSS exposure, redaction rules).
 
-## 6. CI poll + hand-off to human
+## 6. Hand-off to human
 
-Run:
+**CODE path:** Run:
 
 ```
 !loom poll-ci <PR> --issue {{issueId}}
@@ -69,6 +79,8 @@ gh pr merge <N> --squash --delete-branch
 themselves.
 
 Optional: the human can fire `loom merge-gate <PR> --issue {{issueId}}` after they're planning to merge; it polls until the PR is merged (by any means) or a halt signal arrives, then returns.
+
+**DOCUMENT path:** skip CI poll (no CI exists for a Linear Document). Post a `🟢 automation:awaiting-review — document ready, your turn` comment that cites the Document URL and any reviewer asks from the meeting. Do **not** wait for signoff — doc reviews are async over hours/days, blocking the Claude session on a label is wasteful. The human reviews, signs off in-document, and moves issue state themselves.
 
 ## 7. Cleanup (always — fire even if halted)
 


### PR DESCRIPTION
## Why

Until now, `/work` assumed every deliverable was a code change that produces a PR. Scribe's dispatch template only emitted a CODE shape (with `OUTPUT: <diff / log / spec / etc.>` — note the misleading "spec"), and §§5–6 hard-coded "subagent opens a PR" + "poll CI."

When a user `/work`'d a spec or plan issue, the subagent followed the prompt literally:
- wrote markdown into the consumer repo's filesystem,
- often force-added past `.gitignore` policies,
- opened a PR that didn't belong there.

This is exactly how it failed on a real run in a downstream consumer this week (private docs repo's `/work RIFT-21`). Closed a PR on the public OSS tree, then closed another on the private docs tree, before realizing the right answer was: don't write a file at all — create a Linear Document. This PR ports that lesson back to loom so adopters don't repeat it.

## What changed

A second deliverable shape — **Linear Document** — threaded end-to-end through the orchestration:

### `skills/work/SKILL.md`

- §1 pre-flight — notes the probe is git/GitHub-only and returns `fresh` for Document deliverables. Duplicate-document avoidance is reviewer-owned until the probe learns Linear.
- §3 meeting — Lead's closing **must** declare a single line: `Deliverable: CODE` or `Deliverable: LINEAR DOCUMENT` (with the Linear project named for documents). Classification is load-bearing.
- §5 execution — dispatch branches on deliverable. CODE includes the consumer repo path. DOCUMENT forbids filesystem writes; subagent creates/updates a Linear Document via the Linear MCP and returns the Document URL.
- §6 hand-off — CODE path runs `loom poll-ci` + posts `automation:awaiting-merge`. DOCUMENT path skips CI (there is none), posts `automation:awaiting-review` with the Document URL, and exits. Doc reviews are async over hours/days; blocking the Claude session on a label is wasteful.
- §7 cleanup unchanged (already neutral).

### `skills/dev-team-template/agents/scribe.md.template`

Dispatch Format section now has two templates side by side: **CODE** and **LINEAR DOCUMENT**. Template chosen by Lead's closing declaration. Adopters who run `build-team` get both templates baked into their team's Scribe persona.

### `skills/dev-team-template/SKILL.md.template`

Meeting format step 3 reflects that Lead's close includes a deliverable-type declaration. (One-line addition; doesn't change anything else about the team-meeting flow.)

### Docs

- `docs/quickstart.md` — `/work` walkthrough steps 5–7 now cover both paths.
- `docs/dispatch-gate.md` — "Output format" review-checklist bullet acknowledges Document URL.
- `README.md` — one-liner under "What you get" so adopters know the feature exists before reading the deeper docs.

## Out of scope

- **No CLI changes.** `probe.ts` and the six subcommands are untouched. DOCUMENT path short-circuits through the existing `cleanup` subcommand.
- A follow-up could add a `resume-document` probe state (so reruns update an existing Document instead of creating a duplicate) and/or a `--poll-doc-signoff` subcommand for symmetric review-blocking. Defer until a use case appears.

## Test plan

- [x] `npm test` in `packages/cli/` → **153/153**
- [x] `npm run typecheck` → clean
- [x] Read SKILL.md + scribe.md.template + SKILL.md.template back end-to-end: does a Lead close `Deliverable: LINEAR DOCUMENT` route correctly through §§3→5→6?
- [ ] Adopter validation: a downstream user running `loom init` + `build-team` then `/work`'ing a spec issue should land as a Linear Document, not a PR.